### PR TITLE
Switch tests to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "rimraf dist && mkdirp dist && cpy README.md bin.d.ts dist && rollup -c && package-json-minifier",
-    "publish": "npm run build && cd dist && npm publish"
+    "publish": "npm run build && cd dist && npm publish",
+    "test": "node --import tsx --test test/test.ts"
   },
   "author": "Juyeong Maing <mjy9088@naver.com>",
   "repository": {
@@ -25,11 +26,14 @@
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.3",
+    "@types/node": "^24.0.7",
     "cpy-cli": "^5.0.0",
     "mkdirp": "^3.0.1",
     "package.json-minifier": "^0.0.4",
     "rimraf": "^5.0.1",
     "rollup": "^3.28.1",
-    "rollup-plugin-shebang-bin": "^0.0.5"
+    "rollup-plugin-shebang-bin": "^0.0.5",
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
   }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,23 @@
+import { mkdtemp, writeFile, rm, readFile } from 'fs/promises';
+import { spawnSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('generated file sets variable', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'mode-'));
+  try {
+    const config = { variableName: 'myDarkMode' };
+    await writeFile(path.join(tmp, 'mode.config.json'), JSON.stringify(config));
+    const result = spawnSync(process.execPath, [path.resolve(__dirname, '../bin.js')], { cwd: tmp });
+    assert.strictEqual(result.status, 0, result.stderr?.toString() || 'process failed');
+    const output = await readFile(path.join(tmp, 'mode.js'), 'utf8');
+    assert.match(output, /window\['myDarkMode'\]/, 'variable not initialized correctly');
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- convert node test to TypeScript
- add tsx, typescript and @types/node devDeps
- run tests via `node --import tsx --test`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6862a7c3b7c483289f3b24da59697d9f